### PR TITLE
Namespace NullObject to avoid collisions

### DIFF
--- a/lib/irobot/logger.rb
+++ b/lib/irobot/logger.rb
@@ -3,7 +3,7 @@ require 'null_object'
 module Irobot
   module Logger
     def logger
-      @logger ||= Irobot.config.fetch(:logger, ::NullObject.new)
+      @logger ||= Irobot.config.fetch(:logger, NullObject.new)
     end
   end
 end

--- a/lib/null_object.rb
+++ b/lib/null_object.rb
@@ -1,24 +1,26 @@
-class NullObject
-  def method_missing(*args, &block)
-    nil
+module Irobot
+  class NullObject
+    def method_missing(*args, &block)
+      nil
+    end
+
+    def present?
+      false
+    end
+
+    def nil?
+      true
+    end
+
+    def to_ary
+      []
+    end
   end
 
-  def present?
-    false
-  end
-
-  def nil?
-    true
-  end
-
-  def to_ary
-    []
-  end
-end
-
-def Maybe(value)
-  case value
-  when nil then NullObject.new
-  else value
+  def Maybe(value)
+    case value
+    when nil then NullObject.new
+    else value
+    end
   end
 end


### PR DESCRIPTION
Irobot's `NullObject` was overriding OSE's version. 